### PR TITLE
coalescer.py with empty values

### DIFF
--- a/analysis_scripts/coalescer.py
+++ b/analysis_scripts/coalescer.py
@@ -8,7 +8,7 @@ import argparse, glob, re
 
 parser=argparse.ArgumentParser(description='Merge OBRMS output files into 1 file')
 parser.add_argument('-s','--suffix',type=str, required=True, help='Suffix of files to stick together. Assumes filenames are *<SUFFIX><VALUE>.rmsds')
-parser.add_argument('-v','--values',type=str, default="",nargs='+',help='Values to be searched combined with suffix. Defaults to empty string. Accepts any number of arguments.')
+parser.add_argument('-v','--values',type=str, default=[""],nargs='+',help='Values to be searched combined with suffix. Defaults to empty string. Accepts any number of arguments.')
 parser.add_argument('-r','--dataroot',type=str,required=True, help='Root of directories to search')
 parser.add_argument('-o','--outfilename',type=str,required=True, help='Name of output file')
 parser.add_argument('-d','--dirlist',type=str,required=True, help='File containing directory names to work on.')


### PR DESCRIPTION
_Please feel free to ignore this PR since my data is organized a bit differently (I did not use `make_gnina_cmds.py`)._

I need to use `coalescer.py` without `--values`, however the default is an empty string and therefore the loop  `for val in args.values:` is skipped, resulting in an empty CSV file.

This PR changes the default `--values` to a list containing an empty string, so that the loop runs once. 
